### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM jlesage/baseimage-gui:alpine-3.12-glibc
 
 # Define software versions.
 ARG JAVAJRE_VERSION=8.265.01.1
-ARG TMM_VERSION=3.1.11
+ARG TMM_VERSION=3.1.12.1
 
 # Define software download URLs.
 ARG TMM_URL=http://release.tinymediamanager.org/v3/dist/tmm_${TMM_VERSION}_linux.tar.gz


### PR DESCRIPTION
Upgrade to v3.1.12.1 (latest 3.n release, from Dec 22nd 2020)